### PR TITLE
Update SMADB_Backup.sql

### DIFF
--- a/SMAUtility_OpCon20/SMADB_Backup.sql
+++ b/SMAUtility_OpCon20/SMADB_Backup.sql
@@ -9,7 +9,7 @@ SET QUOTED_IDENTIFIER ON
 GO
 BACKUP DATABASE [$(DatabaseName)] TO DISK = '$(PathToFullBackupFile)' WITH INIT
 GO
-BACKUP LOG [$(DatabaseName)] TO DISK = '$(PathToTranLogBackupFile)' WITH NOINIT
+BACKUP LOG [$(DatabaseName)] TO DISK = '$(PathToTranLogBackupFile)' WITH INIT
 GO
 SET QUOTED_IDENTIFIER OFF
 GO


### PR DESCRIPTION
Via WITH INIT the BACKUP DATABASE in this script overwrites the existing database backup with a new one. The BACKUP LOG should do the same. When the script runs you back up the database at that point in time. There is no need to retain preceding transaction log records, therefore, BACKUP LOG should also be WITH INIT. Thank you.

Closes #4 