### PR TITLE
Update SMADB_Backup.sql

### DIFF
--- a/SMAUtility_OpCon20/SMADB_Backup.sql
+++ b/SMAUtility_OpCon20/SMADB_Backup.sql
@@ -9,7 +9,7 @@ SET QUOTED_IDENTIFIER ON
 GO
 BACKUP DATABASE [$(DatabaseName)] TO DISK = '$(PathToFullBackupFile)' WITH INIT
 GO
-BACKUP LOG [$(DatabaseName)] TO DISK = '$(PathToTranLogBackupFile)' WITH NOINIT
+BACKUP LOG [$(DatabaseName)] TO DISK = '$(PathToTranLogBackupFile)' WITH INIT
 GO
 SET QUOTED_IDENTIFIER OFF
 GO


### PR DESCRIPTION
The SMADB_Backup.sql script should have WITH INIT for the TLOG backup, which creates a fresh tlog backup file every night. With NOINIT just appends the existing log forever(or until the HDD runs out of space)